### PR TITLE
Version for shiny

### DIFF
--- a/Ska/tdb/__init__.py
+++ b/Ska/tdb/__init__.py
@@ -3,7 +3,7 @@ import ska_helpers
 
 from .tdb import *
 
-__version__ = ska_helpers.get_version(__package__)
+__version__ = ska_helpers.get_version('Ska.tdb')
 
 
 def test(*args, **kwargs):


### PR DESCRIPTION
## Description

Make pytest no longer fail because of issues with ska_helpers and version.

## Testing

- [x] Passes unit tests on MacOS ska3-shiny
- [x] Passes unit tests on MacOS ska3 (flight)
